### PR TITLE
Fixed schema mismatch validation errors when sending events via the solution API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2022-01-30
+#### Fixed
+- Fixed schema mismatch validation errors when sending events via the solution API
+
 ## [1.1.1] - 2021-07-30
 ### Updated
 - Updated JSON Schema validation version (ajv library) in events processing Lambda function

--- a/source/services/events-processing/lib/event.js
+++ b/source/services/events-processing/lib/event.js
@@ -80,10 +80,13 @@ class Event {
         metadata.api = {};
         if (input.aws_ga_api_requestId) { 
           metadata.api.request_id = input.aws_ga_api_requestId; 
+          delete input.aws_ga_api_requestId;
         }
         if (input.aws_ga_api_requestTimeEpoch) {
           metadata.api.request_time_epoch = input.aws_ga_api_requestTimeEpoch;
+          delete input.aws_ga_api_requestTimeEpoch;
         }
+        delete input.aws_ga_api_validated_flag;
       }
       
       // Retrieve application config from Applications table


### PR DESCRIPTION
Fixed schema mismatch validation errors when sending events via the solution API

*Issue #, if available:* https://github.com/awslabs/game-analytics-pipeline/issues/1

*Description of changes:* removing / deleting the three attributes `aws_ga_api_requestId`, `aws_ga_api_requestTimeEpoch`, and `aws_ga_api_validated_flag` after they have been processed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
